### PR TITLE
Set for auto update upon add_value, updated examples with display checking

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -54,7 +54,7 @@ class Sparkline(displayio.Group):
             ):  # if list is full, remove the first item
                 self._spark_list.pop(0)
             self._spark_list.append(value)
-            # self.update()
+            self.update()
 
     @staticmethod
     def _xintercept(

--- a/examples/display_shapes_sparkline_simpletest.py
+++ b/examples/display_shapes_sparkline_simpletest.py
@@ -71,7 +71,7 @@ if "DISPLAY" not in dir(board):
         display_bus,
         width=DISPLAY_WIDTH,
         height=DISPLAY_HEIGHT,
-        rotation=180, # The rotation can be adjusted to match your configuration.
+        rotation=180,  # The rotation can be adjusted to match your configuration.
         auto_refresh=True,
         native_frames_per_second=90,
     )
@@ -105,7 +105,7 @@ myGroup = displayio.Group(max_size=1)
 myGroup.append(mySparkline1)
 
 
-# Add myGroup (containing the sparkline) to the display 
+# Add myGroup (containing the sparkline) to the display
 display.show(myGroup)
 
 # Start the main loop
@@ -119,7 +119,7 @@ while True:
     # values (between 0 and 10) will fit within the visible range of this sparkline
     mySparkline1.add_value(random.uniform(0, 10))
 
-    # turn the display auto_refresh back on 
+    # turn the display auto_refresh back on
     display.auto_refresh = True
 
     # The display seems to be less jittery if a small sleep time is provided

--- a/examples/display_shapes_sparkline_simpletest.py
+++ b/examples/display_shapes_sparkline_simpletest.py
@@ -30,12 +30,10 @@ import random
 import time
 from adafruit_display_shapes.sparkline import Sparkline
 
-
-
-# from sparkline import sparkline # use this if sparkline.py is used to define the sparkline Class
-
 if "DISPLAY" not in dir(board):
     # Setup the LCD display with driver
+    # You may need to change this to match the display driver for the chipset
+    # used on your display
     from adafruit_ili9341 import ILI9341
 
     displayio.release_displays()
@@ -73,7 +71,7 @@ if "DISPLAY" not in dir(board):
         display_bus,
         width=DISPLAY_WIDTH,
         height=DISPLAY_HEIGHT,
-        rotation=180,
+        rotation=180, # The rotation can be adjusted to match your configuration.
         auto_refresh=True,
         native_frames_per_second=90,
     )
@@ -92,12 +90,10 @@ else:
 chartWidth = display.width
 chartHeight = display.height
 
-
 # mySparkline1 uses a vertical y range between 0 to 10 and will contain a maximum of 40 items
 mySparkline1 = Sparkline(
     width=chartWidth, height=chartHeight, max_items=40, yMin=0, yMax=10, x=0, y=0
 )
-
 
 # Create a group to hold the sparkline and append the sparkline into the group (myGroup)
 #
@@ -105,23 +101,25 @@ mySparkline1 = Sparkline(
 # group will set which is on top.  Latter elements are displayed on top of former elemtns.
 myGroup = displayio.Group(max_size=1)
 
+# add the sparkline into myGroup
 myGroup.append(mySparkline1)
 
 
-# Display myGroup that contains the sparkline
+# Add myGroup (containing the sparkline) to the display 
 display.show(myGroup)
-
 
 # Start the main loop
 while True:
+
+    # turn off the auto_refresh of the display while modifying the sparkline
+    display.auto_refresh = False
 
     # add_value: add a new value to a sparkline
     # Note: The y-range for mySparkline1 is set to 0 to 10, so all these random
     # values (between 0 and 10) will fit within the visible range of this sparkline
     mySparkline1.add_value(random.uniform(0, 10))
 
-    display.auto_refresh = False
-    mySparkline1.update()
+    # turn the display auto_refresh back on 
     display.auto_refresh = True
 
     # The display seems to be less jittery if a small sleep time is provided

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -75,7 +75,7 @@ if "DISPLAY" not in dir(board):
         display_bus,
         width=DISPLAY_WIDTH,
         height=DISPLAY_HEIGHT,
-        rotation=180, # The rotation can be adjusted to match your configuration.
+        rotation=180,  # The rotation can be adjusted to match your configuration.
         auto_refresh=True,
         native_frames_per_second=90,
     )
@@ -91,8 +91,8 @@ else:
 ##########################################
 
 # Baseline size of the sparkline chart, in pixels.
-chartWidth = display.width-50
-chartHeight = display.height-50
+chartWidth = display.width - 50
+chartHeight = display.height - 50
 
 font = terminalio.FONT
 
@@ -190,4 +190,3 @@ while True:
     # The display seems to be less jittery if a small sleep time is provided
     # You can adjust this to see if it has any effect
     time.sleep(0.01)
-

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -34,64 +34,65 @@ from adafruit_display_text import label
 from adafruit_display_shapes.line import Line
 from adafruit_display_shapes.rect import Rect
 
-import gc
+if "DISPLAY" not in dir(board):
+    # Setup the LCD display with driver
+    # You may need to change this to match the display driver for the chipset
+    # used on your display
+    from adafruit_ili9341 import ILI9341
 
-# from sparkline import sparkline # use this if sparkline.py is used to define the sparkline Class
+    displayio.release_displays()
 
+    # setup the SPI bus
+    spi = board.SPI()
+    tft_cs = board.D9  # arbitrary, pin not used
+    tft_dc = board.D10
+    tft_backlight = board.D12
+    tft_reset = board.D11
 
-# Setup the LCD display
+    while not spi.try_lock():
+        spi.configure(baudrate=32000000)
+        pass
+    spi.unlock()
 
-displayio.release_displays()
+    display_bus = displayio.FourWire(
+        spi,
+        command=tft_dc,
+        chip_select=tft_cs,
+        reset=tft_reset,
+        baudrate=32000000,
+        polarity=1,
+        phase=1,
+    )
 
+    print("spi.frequency: {}".format(spi.frequency))
 
-# setup the SPI bus
-spi = board.SPI()
-tft_cs = board.D9  # arbitrary, pin not used
-tft_dc = board.D10
-tft_backlight = board.D12
-tft_reset = board.D11
+    # Number of pixels in the display
+    DISPLAY_WIDTH = 320
+    DISPLAY_HEIGHT = 240
 
-while not spi.try_lock():
-    spi.configure(baudrate=32000000)
-    pass
-spi.unlock()
+    # create the display
+    display = ILI9341(
+        display_bus,
+        width=DISPLAY_WIDTH,
+        height=DISPLAY_HEIGHT,
+        rotation=180, # The rotation can be adjusted to match your configuration.
+        auto_refresh=True,
+        native_frames_per_second=90,
+    )
 
-display_bus = displayio.FourWire(
-    spi,
-    command=tft_dc,
-    chip_select=tft_cs,
-    reset=tft_reset,
-    baudrate=32000000,
-    polarity=1,
-    phase=1,
-)
-
-print("spi.frequency: {}".format(spi.frequency))
-
-# Number of pixels in the display
-DISPLAY_WIDTH = 320
-DISPLAY_HEIGHT = 240
-
-# create the display
-display = ILI9341(
-    display_bus,
-    width=DISPLAY_WIDTH,
-    height=DISPLAY_HEIGHT,
-    rotation=180,
-    auto_refresh=True,
-    native_frames_per_second=90,
-)
-
-# reset the display to show nothing.
-display.show(None)
+    # reset the display to show nothing.
+    display.show(None)
+else:
+    # built-in display
+    display = board.DISPLAY
 
 ##########################################
 # Create background bitmaps and sparklines
 ##########################################
 
 # Baseline size of the sparkline chart, in pixels.
-chartWidth = 270
-chartHeight = 180
+chartWidth = display.width-50
+chartHeight = display.height-50
 
 font = terminalio.FONT
 
@@ -168,24 +169,21 @@ myGroup.append(
     )
 )
 
-
-# Display myGroup that contains all the bitmap TileGrids and sparklines
+# Set the display to show myGroup that contains the sparkline and other graphics
 display.show(myGroup)
-
 
 # Start the main loop
 while True:
+
+    # Turn off auto_refresh to prevent partial updates of the screen during updates
+    # of the sparkline drawing
+    display.auto_refresh = False
 
     # add_value: add a new value to a sparkline
     # Note: The y-range for mySparkline1 is set to 0 to 10, so all these random
     # values (between 0 and 10) will fit within the visible range of this sparkline
     mySparkline1.add_value(random.uniform(0, 10))
 
-    # Turn off auto_refresh to prevent partial updates of the screen during updates
-    # of the sparkline drawing
-    display.auto_refresh = False
-    # Update all the sparklines
-    mySparkline1.update()
     # Turn on auto_refresh for the display
     display.auto_refresh = True
 
@@ -193,5 +191,3 @@ while True:
     # You can adjust this to see if it has any effect
     time.sleep(0.01)
 
-    # Uncomment the next line to print the amount of available memory
-    # print('memory free: {}'.format(gc.mem_free()))

--- a/examples/display_shapes_sparkline_triple.py
+++ b/examples/display_shapes_sparkline_triple.py
@@ -75,7 +75,7 @@ if "DISPLAY" not in dir(board):
         display_bus,
         width=DISPLAY_WIDTH,
         height=DISPLAY_HEIGHT,
-        rotation=180, # The rotation can be adjusted to match your configuration.
+        rotation=180,  # The rotation can be adjusted to match your configuration.
         auto_refresh=True,
         native_frames_per_second=90,
     )


### PR DESCRIPTION
Changed `add_value` so that a display `update` is performed after each value is added.  This eliminates the need to call `update`.  I think this will simplify usage of Sparkline.

I updated the three examples to accommodate the change to eliminate the `update` requirement.

Added to all three examples with @foamyguy 's cool automatic checking of the `DISPLAY` for internal vs. external display.